### PR TITLE
Expand external-db.json to cover more scenarios.

### DIFF
--- a/src/main/resources/faux/external-db.json
+++ b/src/main/resources/faux/external-db.json
@@ -151,11 +151,46 @@
           "author-ip": "192.168.0.9",
           "author-host": "j",
           "client-username": "jane",
-          "status": "Approved",
+          "status": "Pending",
           "comment": "Finally some good stuff!",
           "date": "2013-05-07 16:16:13 Z"
+        },
+        {
+          "filename": "0001-003-Instructions.xls",
+          "author-username": "peter",
+          "author-email": "peter@aviatnet.com",
+          "author-ip": "192.168.0.6",
+          "author-host": "p",
+          "client-username": "peter",
+          "status": "Approved",
+          "comment": "Some changes need to approved",
+          "date": "2013-08-13 16:16:13 Z"
+        },
+        {
+          "filename": "0001-002-Instructions.xls",
+          "author-username": "roger",
+          "author-email": "roger.renault@aviatnet.com",
+          "author-ip": "192.168.0.7",
+          "author-host": "r",
+          "client-username": "roger",
+          "status": "Not Approved",
+          "comment": "Funny changes which can't accepted :(",
+          "date": "2013-08-12 16:16:13 Z"
+        }
+      ],
+      "subscriptions": [
+        {
+          "username": "peter",
+          "email": "peter@aviatnet.com",
+          "options": "bookmark"
+        },
+        {
+          "username": "jane",
+          "email": "jane.jensen@aviatnet.com",
+          "options": "always"
         }
       ]
+
     },
     {
       "number": "0123",
@@ -193,6 +228,18 @@
           "status": "Not Approved",
           "comment": "Let's not do that, OK.",
           "date": "2013-06-02 16:16:13 Z"
+        }
+      ],
+      "subscriptions": [
+        {
+            "username": "vicky",
+            "email": "vicky.vauxhall@aviatnet.com",
+            "options": "always"
+        },
+        {
+            "username": "sue",
+            "email": "sue.suzuki@aviatnet.com",
+            "options": "always bookmark"
         }
       ]
     },

--- a/src/main/scala/vvv/docreg/backend/Backend.scala
+++ b/src/main/scala/vvv/docreg/backend/Backend.scala
@@ -290,9 +290,12 @@ class Backend(directory: Directory, daemonAgent: ActorRef, documentStream: Actor
   }
 
   def documentUpToDate(document: Document, d: DocumentInfo): Boolean = {
-    val weekAgo = T.daysAgo(7)
-    val recentEditor = d.editor != null && d.editorStart != null && d.editorStart.after(weekAgo)
-    val reconcileOutOfDate = document.reconciled == null || document.reconciled.before(weekAgo)
-    document.latest_?(d.version) && !recentEditor && document.access.equalsIgnoreCase(d.access) && !reconcileOutOfDate
+    if (net.liftweb.util.Props.devMode) false
+    else {
+      val weekAgo = T.daysAgo(7)
+      val recentEditor = d.editor != null && d.editorStart != null && d.editorStart.after(weekAgo)
+      val reconcileOutOfDate = document.reconciled == null || document.reconciled.before(weekAgo)
+      document.latest_?(d.version) && !recentEditor && document.access.equalsIgnoreCase(d.access) && !reconcileOutOfDate
+    }
   }
 }


### PR DESCRIPTION
Fixes #10 
- Added subscription parser and sample data with different options (always/bookmark)
- Added sample records for different approval status.
  Fixes done for update documents in dev mode with external-db.json without check for document check
